### PR TITLE
Handle `incomingSettings` and `profileObject` being null (#1504)

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -378,7 +378,10 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         private string GetProfilePathFromProfileObject(PSObject profileObject, ProfileUserKind userKind, ProfileHostKind hostKind)
         {
             string profilePathName = $"{userKind}{hostKind}";
-
+            if (profileObject is null)
+            {
+                return null;
+            }
             string pwshProfilePath = (string)profileObject.Properties[profilePathName].Value;
 
             if (hostKind == ProfileHostKind.AllHosts)

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             LanguageServerSettingsWrapper incomingSettings = request.Settings.ToObject<LanguageServerSettingsWrapper>();
             this._logger.LogTrace("Handling DidChangeConfiguration");
-            if (incomingSettings == null)
+            if (incomingSettings is null || incomingSettings.Powershell is null)
             {
                 this._logger.LogTrace("Incoming settings were null");
                 return await Unit.Task.ConfigureAwait(false);


### PR DESCRIPTION
* Added null check for incomingSettings.Powershell to prevent SendFeatureChangesTelemetry from throwing an exception when accessing Powershell and its properties.

* Added null check in GetProfilePathFromProfileObject to prevent NullReferenceException if profileObject is null.

Co-authored-by: Andrew Schwartzmeyer <andrew@schwartzmeyer.com>