### PR TITLE
Fixed TextReader disposal

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -146,15 +146,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <param name="fileUri">The System.Uri of the file.</param>
         /// <param name="initialBuffer">The initial contents of the script file.</param>
         /// <param name="powerShellVersion">The version of PowerShell for which the script is being parsed.</param>
-        internal ScriptFile(
+        internal static ScriptFile Create(
             DocumentUri fileUri,
             string initialBuffer,
             Version powerShellVersion)
-            : this(
-                  fileUri,
-                  new StringReader(initialBuffer),
-                  powerShellVersion)
+
         {
+            using TextReader textReader = new StringReader(initialBuffer);
+            return new ScriptFile(fileUri, textReader, powerShellVersion);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -275,7 +275,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (!workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile) && initialBuffer != null)
             {
                 scriptFile =
-                    new ScriptFile(
+                    ScriptFile.Create(
                         documentUri,
                         initialBuffer,
                         powerShellVersion);

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
@@ -52,7 +52,7 @@ namespace PowerShellEditorServices.Test.Extensions
         public async Task CanRegisterAndInvokeCommandWithCmdletName()
         {
             string filePath = TestUtilities.NormalizePath(@"C:\Temp\Test.ps1");
-            ScriptFile currentFile = new(new Uri(filePath), "This is a test file", new Version("7.0"));
+            ScriptFile currentFile = ScriptFile.Create(new Uri(filePath), "This is a test file", new Version("7.0"));
             EditorContext editorContext = new(
                 editorOperations: null,
                 currentFile,
@@ -88,7 +88,7 @@ namespace PowerShellEditorServices.Test.Extensions
         public async Task CanRegisterAndInvokeCommandWithScriptBlock()
         {
             string filePath = TestUtilities.NormalizePath(@"C:\Temp\Test.ps1");
-            ScriptFile currentFile = new(new Uri(filePath), "This is a test file", new Version("7.0"));
+            ScriptFile currentFile = ScriptFile.Create(new Uri(filePath), "This is a test file", new Version("7.0"));
             EditorContext editorContext = new(
                 editorOperations: null,
                 currentFile,
@@ -150,7 +150,7 @@ namespace PowerShellEditorServices.Test.Extensions
         public async Task CanUnregisterCommand()
         {
             string filePath = TestUtilities.NormalizePath(@"C:\Temp\Test.ps1");
-            ScriptFile currentFile = new(new Uri(filePath), "This is a test file", new Version("7.0"));
+            ScriptFile currentFile = ScriptFile.Create(new Uri(filePath), "This is a test file", new Version("7.0"));
             EditorContext editorContext = new(
                 editorOperations: null,
                 currentFile,

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -24,7 +24,7 @@ function Get-Sum {
     return $a + $b
 }
 ";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,
@@ -61,7 +61,7 @@ function Get-Sum {
         public void TokenizesStringExpansion()
         {
             const string text = "Write-Host \"$(Test-Property Get-Whatever) $(Get-Whatever)\"";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,
@@ -88,7 +88,7 @@ function Get-A*A {
 }
 Get-A*A
 ";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,
@@ -113,7 +113,7 @@ Get-A*A
         public void RecognizesArrayPropertyInExpandableString()
         {
             const string text = "\"$(@($Array).Count) OtherText\"";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,
@@ -138,7 +138,7 @@ Get-A*A
         public void RecognizesCurlyQuotedString()
         {
             const string text = "“^[-'a-z]*”";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,
@@ -158,7 +158,7 @@ enum MyEnum{
     three
 }
 ";
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -17,7 +17,7 @@ namespace PowerShellEditorServices.Test.Language
         /// </summary>
         private static FoldingReference[] GetRegions(string text)
         {
-            ScriptFile scriptFile = new(
+            ScriptFile scriptFile = ScriptFile.Create(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
                 text,

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -24,7 +24,7 @@ namespace PowerShellEditorServices.Test.Session
             ? s_lazyDriveLetter.Value
             : string.Empty;
 
-        internal static ScriptFile CreateScriptFile(string path) => new(path, "", VersionUtils.PSVersion);
+        internal static ScriptFile CreateScriptFile(string path) => ScriptFile.Create(path, "", VersionUtils.PSVersion);
 
         // Remember that LSP does weird stuff to the drive letter, so we have to convert it to a URI
         // and back to ensure that drive letter gets lower cased and everything matches up.


### PR DESCRIPTION
Added static Create method to create a new instance of the ScriptFile from a string to prevent the TextReader from never being disposed.

https://stackoverflow.com/questions/2988977/passing-idisposable-objects-through-constructor-chains